### PR TITLE
set-cstate-latency.pl: Skip non-state sysfs subdirectories

### DIFF
--- a/bin/set-cstate-latency.pl
+++ b/bin/set-cstate-latency.pl
@@ -24,7 +24,7 @@ sub read_cstates() {
 	my @cstates;
 	my $cpuidle_root = "/sys/devices/system/cpu/cpu0/cpuidle";
 
-	foreach my $state (<$cpuidle_root/*>) {
+	foreach my $state (<$cpuidle_root/state*>) {
 		my ($fh, $name, $latency);
 		my $index = $state;
 		$index =~ s/^state//;


### PR DESCRIPTION
When the kernel is built with CONFIG_CPU_IDLE_MULTIPLE_DRIVERS=y (a common thing on Arm), the sysfs cpuidle root directory contains a "driver" subdirectory, which does not contain any "name" file. This breaks the initial enumeration of available cpuidle states, rendering this script unusable for such kernels.

Since all cpuidle states are created through a "state%d" printf format specifier, fix the script by making the glob pattern more specific.