### PR TITLE
ExtractVdsotest: Accept a nsec/call output format

### DIFF
--- a/bin/lib/MMTests/ExtractVdsotest.pm
+++ b/bin/lib/MMTests/ExtractVdsotest.pm
@@ -53,6 +53,13 @@ sub extractReport() {
 
 					$self->addData($op, ++$samples{$op}, $lat);
 				}
+
+				elsif ($line =~ /(\w+):\W+([0-9]+)\s+nsec\/call/) {
+					my $op = "$wl-$1";
+					my $lat = $2;
+
+					$self->addData($op, ++$samples{$op}, $lat);
+				}
 			}
 			close INPUT;
 		}


### PR DESCRIPTION
The parser expects a (presumably older) format with syscalls per second, but recent vdsotest logfiles look something like this:

clock-getres-monotonic-coarse: syscall: 674 nsec/call
clock-getres-monotonic-coarse:    libc: 8 nsec/call
clock-getres-monotonic-coarse:    vdso: 6 nsec/call

Parse this output format properly.