### PR TITLE
install-depends: add a missing entry in %package_map

### DIFF
--- a/bin/install-depends
+++ b/bin/install-depends
@@ -51,6 +51,7 @@ my %package_map = (
 	"debian::MPlayer"			=> "mplayer",
 	"debian::perl-Math-Round"		=> "libmath-round-perl",
 	"debian::perl-File-Slurp"		=> "libfile-slurp-perl",
+	"debian::perl-File-Which"		=> "libfile-which-perl",
 	"debian::perl-Time-HiRes"		=> "perl",
 	"debian::popt-devel"			=> "libpopt-dev",
 	"debian::python3-devel"			=> "python3-dev",


### PR DESCRIPTION
The `perl-File-Which` dependency is installed in `compare-kernels.sh` script. Because the corresponding apt package's name was missing, `install-depends perl-File-Which` command failed on Ubuntu.