### PR TITLE
OpenBLAS: Update version and add install dep for gcc-fortran

### DIFF
--- a/shellpack_src/src/blasbuild/blasbuild-bench
+++ b/shellpack_src/src/blasbuild/blasbuild-bench
@@ -1,5 +1,5 @@
 #!/bin/bash
-###SHELLPACK preamble blasbuild-bench blas-v0.3.10
+###SHELLPACK preamble blasbuild-bench blas-v0.3.30
 
 ###SHELLPACK parseargBegin
 ###SHELLPACK parseargInstall
@@ -7,6 +7,6 @@
 ###SHELLPACK parseargEnd
 ###SHELLPACK monitor_hooks
 
-export BLAS_VERSION="v0.3.10"
+export BLAS_VERSION="v0.3.30"
 # dependencies
 ###SHELLPACK check_external_install_required blasbuild     blasbuild-${BLAS_VERSION}         ${BLAS_VERSION}

--- a/shellpack_src/src/blasbuild/blasbuild-install
+++ b/shellpack_src/src/blasbuild/blasbuild-install
@@ -1,7 +1,9 @@
 #!/bin/bash
-###SHELLPACK preamble blasbuild v0.3.10
+###SHELLPACK preamble blasbuild v0.3.30
 GIT_LOCATION=https://github.com/xianyi/OpenBLAS
 MIRROR_LOCATION="$WEBROOT/blasbuild/"
+
+install-depends gcc-fortran
 
 ###SHELLPACK parseargBegin
 ###SHELLPACK parseargEnd


### PR DESCRIPTION
Avoid compilation issue:
OpenBLAS: Detecting fortran compiler failed. Can only compile BLAS and f2c-converted LAPACK.