### PR TITLE
run-mmtests: Add install dependencies for wget, procps, kmod and gcc-c++

### DIFF
--- a/run-mmtests.sh
+++ b/run-mmtests.sh
@@ -166,7 +166,7 @@ if [ -d $SCRIPTDIR/work/sources/ ]; then
 fi
 
 # required in common.sh
-install-depends gawk
+install-depends gawk procps wget
 
 . $SCRIPTDIR/shellpacks/common.sh
 . $SCRIPTDIR/shellpacks/common-config.sh
@@ -227,10 +227,10 @@ if [ $? -ne 0 ]; then
 	install-depends perl-Time-HiRes
 fi
 install-depends autoconf automake bc binutils-devel btrfsprogs bzip2	\
-	coreutils cpupower e2fsprogs expect expect-devel gcc hdparm	\
+	coreutils cpupower e2fsprogs expect expect-devel gcc gcc-c++ hdparm	\
 	hwloc libtool make patch psmisc tcl	\
-	time wget xfsprogs xfsprogs-devel xz which perl-File-Slurp netcat-openbsd \
-	gzip hostname iproute2
+	time xfsprogs xfsprogs-devel xz which perl-File-Slurp netcat-openbsd \
+	gzip hostname iproute2 kmod
 
 # if we're running in a vm, and the firewall seems on, let's (try to) whitelist
 # the host, so we can communicate with it. this should work fine if we're using


### PR DESCRIPTION
wget and procps are used in common.sh.
kmod provides 'lsmod', which is used in run-mmtests.sh.
gcc-c++ is required by multiple tests.